### PR TITLE
Fix Firebase Admin init on Render (fixes #3)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -27,16 +27,12 @@ const serviceAccountPath = "/etc/secrets/firebase-service-account.json";
 
 if (!admin.apps.length) {
   if (!fs.existsSync(serviceAccountPath)) {
-    console.error("❌ Firebase service account file not found");
+    console.error("❌ Firebase service account file not found at:", serviceAccountPath);
     process.exit(1);
   }
 
-  const serviceAccount = JSON.parse(
-    fs.readFileSync(serviceAccountPath, "utf8")
-  );
-
   admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount),
+    credential: admin.credential.cert(serviceAccountPath),
   });
 
   console.log("✅ Firebase Admin initialized");


### PR DESCRIPTION
This PR updates Firebase Admin initialization to load credentials directly from the Render secret file path (admin.credential.cert(serviceAccountPath)) instead of JSON.parse(fs.readFileSync(...)), which should prevent the startup crash ("undefined" is not valid JSON). I haven’t been able to verify on your Render service, but the change follows Firebase Admin’s supported usage for service account files. Please review