### PR TITLE
Add public LandingPage and route unauthenticated users to it

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-d
 import { AppContext } from "./context/appContextStore";
 
 import Navbar from "./components/Navbar";
+import LandingPage from "./pages/LandingPage";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
 import AdminDashboard from "./pages/AdminDashboard";
@@ -48,7 +49,7 @@ const App = () => {
       {showNavbar && <Navbar />}
 
       <Routes>
-        <Route path="/" element={<RootRedirect />} />
+        <Route path="/" element={user ? <RootRedirect /> : <LandingPage />} />
         {/* Public */}
         <Route path="/login" element={user ? <RootRedirect /> : <Login />} />
         <Route path="/register" element={user ? <RootRedirect /> : <Register />} />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -62,6 +62,58 @@ textarea {
   gap: 24px;
 }
 
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+  align-items: center;
+}
+
+.hero-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.pill {
+  align-self: flex-start;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: #e0e7ff;
+  color: #4338ca;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-title {
+  font-size: 36px;
+  margin: 0;
+  color: #0f172a;
+}
+
+.hero-subtitle {
+  margin: 0;
+  color: #64748b;
+  font-size: 16px;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.hero-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.hero-card {
+  min-height: 140px;
+}
+
 .page-header {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -1,0 +1,70 @@
+import { Link } from "react-router-dom";
+
+export default function LandingPage() {
+  return (
+    <div className="page">
+      <div className="page-content">
+        <section className="hero">
+          <div className="hero-content">
+            <span className="pill">Fleetiva Roadlines</span>
+            <h1 className="hero-title">
+              Smart freight matching for every shipper, driver, and admin team.
+            </h1>
+            <p className="hero-subtitle">
+              Post loads, match trucks, and keep shipments moving with real-time
+              dashboards built for logistics teams.
+            </p>
+            <div className="hero-actions">
+              <Link to="/register" className="btn btn-primary">
+                Get Started
+              </Link>
+              <Link to="/login" className="btn btn-secondary">
+                Sign In
+              </Link>
+            </div>
+          </div>
+          <div className="hero-grid">
+            <div className="card hero-card">
+              <h3 className="section-title">Live Load Matching</h3>
+              <p className="text-muted">
+                Instantly pair posted loads with available trucks and dispatch
+                within minutes.
+              </p>
+            </div>
+            <div className="card hero-card">
+              <h3 className="section-title">Role-Based Dashboards</h3>
+              <p className="text-muted">
+                Tailored experiences for customers, drivers, admins, and super
+                admins.
+              </p>
+            </div>
+            <div className="card hero-card">
+              <h3 className="section-title">Operational Visibility</h3>
+              <p className="text-muted">
+                Track bookings, payments, and system activity with clear, clean
+                reporting.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="card-grid cols-2">
+          <div className="card">
+            <h3 className="section-title">For Shippers</h3>
+            <p className="text-muted">
+              Create loads, receive matches, and monitor delivery milestones in
+              one place.
+            </p>
+          </div>
+          <div className="card">
+            <h3 className="section-title">For Drivers</h3>
+            <p className="text-muted">
+              Post truck availability, manage assignments, and keep your fleet
+              utilized.
+            </p>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Replace the placeholder/demo experience on the root route with the real Fleetiva landing UI so public visitors see the application branding and CTAs.
- Ensure authenticated users still get redirected to their role-specific dashboards while unauthenticated visitors land on a proper marketing/entry page.

### Description
- Added `frontend/src/pages/LandingPage.jsx` to provide a public landing hero, CTAs and informational cards for shippers/drivers.
- Updated `frontend/src/App.jsx` to import `LandingPage` and render `/<Root>` as `LandingPage` for unauthenticated users while preserving `RootRedirect` for authenticated users.
- Added hero and landing styles to `frontend/src/index.css` to style the new landing components.
- Commit message for the change: `Add Fleetiva landing page routing`.

### Testing
- Ran `npm run build` in `frontend` and the Vite production build completed successfully with output files generated (build succeeded).
- Started the dev server and loaded the root page (dev server reachable); a programmatic screenshot of the landing page was produced to verify the UI rendered (dev verification succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986dcb743948331a761794acbf6808a)