### PR TITLE
Use CustomerDashboard alias and avoid AdminDashboard redeclaration

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,8 +7,8 @@ import Navbar from "./components/Navbar";
 import LandingPage from "./pages/LandingPage";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
-import AdminDashboard from "./pages/AdminDashboard";
-import Dashboard from "./pages/Dashboard";
+import AdminDashboardPage from "./pages/AdminDashboard";
+import CustomerDashboard from "./pages/CustomerDashboard";
 import DriverDashboard from "./pages/DriverDashboard";
 import SuperAdminDashboard from "./pages/SuperAdminDashboard";
 import SystemLogs from "./pages/SystemLogs";
@@ -61,7 +61,7 @@ const App = () => {
           path="/admin"
           element={
             <ProtectedRoute role="admin">
-              <AdminDashboard />
+              <AdminDashboardPage />
             </ProtectedRoute>
           }
         />
@@ -99,7 +99,7 @@ const App = () => {
           path="/dashboard"
           element={
             <ProtectedRoute role="customer">
-              <Dashboard />
+              <CustomerDashboard />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/pages/CustomerDashboard.jsx
+++ b/frontend/src/pages/CustomerDashboard.jsx
@@ -1,0 +1,3 @@
+import Dashboard from "./Dashboard";
+
+export default Dashboard;


### PR DESCRIPTION
### Motivation
- Fix runtime import/identifier errors in `App.jsx` caused by duplicate or mismatched dashboard imports and the missing customer dashboard alias.

### Description
- Rename the admin import to `AdminDashboardPage` in `frontend/src/App.jsx` to avoid identifier collisions.
- Replace the customer route usage of `Dashboard` with the `CustomerDashboard` import in `frontend/src/App.jsx`.
- Add `frontend/src/pages/CustomerDashboard.jsx` which re-exports the existing `Dashboard` component as the `CustomerDashboard` alias.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986f7298a14833195c7e9b7a66f0b19)