### PR TITLE
Guard Firebase auth flows when config is missing

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,8 +7,8 @@ import Navbar from "./components/Navbar";
 import LandingPage from "./pages/LandingPage";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
-import AdminDashboard from "./pages/AdminDashboard";
-import Dashboard from "./pages/Dashboard";
+import AdminDashboardPage from "./pages/AdminDashboard";
+import CustomerDashboard from "./pages/CustomerDashboard";
 import DriverDashboard from "./pages/DriverDashboard";
 import SuperAdminDashboard from "./pages/SuperAdminDashboard";
 import SystemLogs from "./pages/SystemLogs";
@@ -61,7 +61,7 @@ const App = () => {
           path="/admin"
           element={
             <ProtectedRoute role="admin">
-              <AdminDashboard />
+              <AdminDashboardPage />
             </ProtectedRoute>
           }
         />
@@ -99,7 +99,7 @@ const App = () => {
           path="/dashboard"
           element={
             <ProtectedRoute role="customer">
-              <Dashboard />
+              <CustomerDashboard />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/OAuth.jsx
+++ b/frontend/src/components/OAuth.jsx
@@ -6,8 +6,13 @@ import { safeStorage } from "../utils/storage";
 
 export default function OAuth() {
   const navigate = useNavigate();
+  const authUnavailable = !auth || !googleProvider;
 
   const handleGoogleClick = async () => {
+    if (authUnavailable) {
+      console.warn("Firebase authentication is not configured.");
+      return;
+    }
     try {
       const result = await signInWithPopup(auth, googleProvider);
       const idToken = await result.user.getIdToken();
@@ -21,7 +26,12 @@ export default function OAuth() {
   };
 
   return (
-    <button type="button" onClick={handleGoogleClick} style={styles.button}>
+    <button
+      type="button"
+      onClick={handleGoogleClick}
+      style={styles.button}
+      disabled={authUnavailable}
+    >
       Continue with Google
     </button>
   );

--- a/frontend/src/context/AppContext.jsx
+++ b/frontend/src/context/AppContext.jsx
@@ -9,6 +9,11 @@ export const AppProvider = ({ children }) => {
   const [user, setUser] = useState(null);
 
   useEffect(() => {
+    if (!auth) {
+      console.warn("Firebase auth unavailable. Skipping auth listener.");
+      return undefined;
+    }
+
     const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
       if (firebaseUser) {
         setUser(firebaseUser);
@@ -23,6 +28,7 @@ export const AppProvider = ({ children }) => {
   }, []);
 
   const logout = async () => {
+    if (!auth) return;
     setLoading(true);
     try {
       await signOut(auth);

--- a/frontend/src/firebase.js
+++ b/frontend/src/firebase.js
@@ -11,9 +11,19 @@ const firebaseConfig = {
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
 };
 
-const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
-const googleProvider = new GoogleAuthProvider();
-googleProvider.setCustomParameters({ prompt: "select_account" });
+const hasFirebaseConfig = Object.values(firebaseConfig).every(Boolean);
 
-export { app, auth, googleProvider };
+let app = null;
+let auth = null;
+let googleProvider = null;
+
+if (hasFirebaseConfig) {
+  app = initializeApp(firebaseConfig);
+  auth = getAuth(app);
+  googleProvider = new GoogleAuthProvider();
+  googleProvider.setCustomParameters({ prompt: "select_account" });
+} else {
+  console.warn("Firebase configuration is missing. Auth features are disabled.");
+}
+
+export { app, auth, googleProvider, hasFirebaseConfig };

--- a/frontend/src/pages/CustomerDashboard.jsx
+++ b/frontend/src/pages/CustomerDashboard.jsx
@@ -1,0 +1,3 @@
+import Dashboard from "./Dashboard";
+
+export default Dashboard;

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -8,6 +8,7 @@ import { auth, googleProvider } from "../firebase";
 export default function Login() {
   const navigate = useNavigate();
   const { loading, setLoading } = useContext(AppContext);
+  const authUnavailable = !auth || !googleProvider;
 
   const [error, setError] = useState("");
   const [formData, setFormData] = useState({
@@ -18,6 +19,10 @@ export default function Login() {
   const handleLogin = async (e) => {
     e.preventDefault();
     if (loading) return;
+    if (authUnavailable) {
+      setError("Authentication is not configured. Please set Firebase env values.");
+      return;
+    }
 
     setError("");
     setLoading(true);
@@ -34,6 +39,10 @@ export default function Login() {
 
   const handleGoogleLogin = async () => {
     if (loading) return;
+    if (authUnavailable) {
+      setError("Authentication is not configured. Please set Firebase env values.");
+      return;
+    }
 
     setError("");
     setLoading(true);
@@ -61,6 +70,11 @@ export default function Login() {
         </p>
 
         {error && <Toast message={error} />}
+        {authUnavailable && (
+          <p className="text-muted" style={{ textAlign: "center", marginTop: 12 }}>
+            Firebase authentication is not configured for this environment.
+          </p>
+        )}
 
         <form onSubmit={handleLogin} className="form" style={{ marginTop: 24 }}>
           <input
@@ -85,13 +99,17 @@ export default function Login() {
             }
           />
 
-          <button type="submit" disabled={loading} className="btn btn-primary">
+          <button
+            type="submit"
+            disabled={loading || authUnavailable}
+            className="btn btn-primary"
+          >
             {loading ? "Signing in..." : "Login"}
           </button>
           <button
             type="button"
             onClick={handleGoogleLogin}
-            disabled={loading}
+            disabled={loading || authUnavailable}
             className="btn btn-secondary"
           >
             Continue with Google

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -8,6 +8,7 @@ import { auth } from "../firebase";
 export default function Register() {
   const navigate = useNavigate();
   const { loading, setLoading } = useContext(AppContext);
+  const authUnavailable = !auth;
 
   const [error, setError] = useState("");
 
@@ -22,6 +23,10 @@ export default function Register() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (loading) return;
+    if (authUnavailable) {
+      setError("Authentication is not configured. Please set Firebase env values.");
+      return;
+    }
 
     setError("");
     setLoading(true);
@@ -47,6 +52,11 @@ export default function Register() {
         </p>
 
         {error && <Toast message={error} />}
+        {authUnavailable && (
+          <p className="text-muted" style={{ textAlign: "center", marginTop: 12 }}>
+            Firebase authentication is not configured for this environment.
+          </p>
+        )}
 
         <form onSubmit={handleSubmit} className="form" style={{ marginTop: 24 }}>
           <input
@@ -101,7 +111,11 @@ export default function Register() {
             <option value="admin">Admin</option>
           </select>
 
-          <button type="submit" disabled={loading} className="btn btn-primary">
+          <button
+            type="submit"
+            disabled={loading || authUnavailable}
+            className="btn btn-primary"
+          >
             {loading ? "Creating account..." : "Register"}
           </button>
         </form>


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes and blank screens caused by missing Firebase environment variables by making auth initialization optional. 
- Provide clear UX feedback and disable auth actions when Firebase is not configured so the app remains usable in non-auth environments.

### Description
- Add Firebase configuration detection in `frontend/src/firebase.js` and export `hasFirebaseConfig`, and only initialize `app`, `auth`, and `googleProvider` when values are present. 
- Skip the Firebase auth listener and short-circuit `logout` when `auth` is unavailable in `frontend/src/context/AppContext.jsx` to avoid runtime errors. 
- Guard UI flows by disabling login/register/OAuth actions and showing a helpful message when Firebase is not configured in `frontend/src/pages/Login.jsx`, `frontend/src/pages/Register.jsx`, and `frontend/src/components/OAuth.jsx`. 
- Minor route/component imports adjusted to use `AdminDashboardPage` and `CustomerDashboard` aliases in `frontend/src/App.jsx`, and `frontend/src/pages/CustomerDashboard.jsx` re-exports the existing `Dashboard` (from earlier change visible in diff).

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified Vite served the app successfully. (succeeded)
- Ran a Playwright script that opened `http://127.0.0.1:4173/login` and captured a screenshot showing the authentication-not-configured message; the script completed and produced an artifact. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986f7298a14833195c7e9b7a66f0b19)