### PR TITLE
Handle Firebase availability; add superadmin, login logging, bilty/billing endpoints and admin UI

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -22,7 +22,7 @@ exports.verifyToken = (req, res, next) => {
 
 exports.authorize = (roles = []) => {
   return (req, res, next) => {
-    if (!roles.includes(req.user.role)) {
+    if (req.user.role !== 'superadmin' && !roles.includes(req.user.role)) {
       return res.status(403).json({ message: "Unauthorized Role" });
     }
     next();

--- a/backend/models/BillingRecord.js
+++ b/backend/models/BillingRecord.js
@@ -1,0 +1,29 @@
+const mongoose = require('mongoose');
+
+const billingRecordSchema = new mongoose.Schema(
+  {
+    booking: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Booking',
+      required: true,
+      unique: true,
+    },
+    customer: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    driver: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    truck: { type: mongoose.Schema.Types.ObjectId, ref: 'Truck' },
+    load: { type: mongoose.Schema.Types.ObjectId, ref: 'Load' },
+    lrNumber: { type: String, index: true },
+    invoiceNumber: { type: String, index: true },
+    freightAmount: { type: Number, required: true, min: 0 },
+    gstAmount: { type: Number, required: true, min: 0 },
+    totalAmount: { type: Number, required: true, min: 0 },
+    advancePaid: { type: Number, default: 0, min: 0 },
+    balanceAmount: { type: Number, required: true, min: 0 },
+    paymentMode: { type: String, enum: ['cash', 'bank', 'upi', 'card'], required: true },
+    paymentStatus: { type: String, enum: ['pending', 'paid'], default: 'pending' },
+    paidAt: { type: Date },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('BillingRecord', billingRecordSchema);

--- a/backend/models/LoginLog.js
+++ b/backend/models/LoginLog.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+const loginLogSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    email: { type: String },
+    provider: { type: String, enum: ['local', 'google', 'firebase'] },
+    status: { type: String, enum: ['success', 'failure'], default: 'success' },
+    ip: { type: String },
+    userAgent: { type: String },
+    reason: { type: String },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('LoginLog', loginLogSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -8,7 +8,7 @@ const userSchema = new mongoose.Schema(
     password: String,
     role: {
       type: String,
-      enum: ["customer", "driver", "admin"],
+      enum: ["customer", "driver", "admin", "superadmin"],
       default: "customer",
     },
     authProvider: {

--- a/backend/routes/bilty.js
+++ b/backend/routes/bilty.js
@@ -1,0 +1,162 @@
+const express = require('express');
+const Bilty = require('../models/Bilty');
+const Booking = require('../models/Booking');
+const BillingRecord = require('../models/BillingRecord');
+const { authenticate, authorize } = require('../middleware/combinedAuth');
+
+const router = express.Router();
+
+const generateLRNumber = () =>
+  `LR-${Date.now().toString(36).toUpperCase()}-${Math.random()
+    .toString(36)
+    .slice(2, 6)
+    .toUpperCase()}`;
+
+const ensureUniqueLRNumber = async (lrNumber) => {
+  let next = lrNumber || generateLRNumber();
+  while (await Bilty.findOne({ lrNumber: next })) {
+    next = generateLRNumber();
+  }
+  return next;
+};
+
+const allowedUpdateFields = new Set([
+  'lrNumber',
+  'consignorName',
+  'consigneeName',
+  'pickupLocation',
+  'dropLocation',
+  'materialType',
+  'weight',
+  'truckType',
+  'driverName',
+  'driverPhone',
+  'vehicleNumber',
+  'freightAmount',
+  'advancePaid',
+  'balanceAmount',
+  'paymentMode',
+  'shipmentStatus',
+]);
+
+router.get('/', authenticate, authorize('admin'), async (req, res) => {
+  const bilties = await Bilty.find()
+    .populate('booking', '_id status paymentStatus')
+    .sort({ createdAt: -1 });
+  res.json(bilties);
+});
+
+router.post('/', authenticate, authorize('admin'), async (req, res) => {
+  const {
+    booking: bookingId,
+    lrNumber,
+    consignorName,
+    consigneeName,
+    pickupLocation,
+    dropLocation,
+    materialType,
+    weight,
+    truckType,
+    driverName,
+    driverPhone,
+    vehicleNumber,
+    freightAmount,
+    advancePaid,
+    balanceAmount,
+    paymentMode,
+    shipmentStatus,
+  } = req.body;
+
+  if (!bookingId) {
+    return res.status(400).json({ message: 'Booking is required.' });
+  }
+
+  const booking = await Booking.findById(bookingId);
+  if (!booking) {
+    return res.status(404).json({ message: 'Booking not found.' });
+  }
+
+  const existing = await Bilty.findOne({ booking: bookingId });
+  if (existing) {
+    return res.status(409).json({ message: 'Bilty already exists for this booking.' });
+  }
+
+  const finalLRNumber = await ensureUniqueLRNumber(lrNumber?.trim());
+
+  const bilty = await Bilty.create({
+    booking: bookingId,
+    lrNumber: finalLRNumber,
+    consignorName,
+    consigneeName,
+    pickupLocation,
+    dropLocation,
+    materialType,
+    weight,
+    truckType,
+    driverName,
+    driverPhone,
+    vehicleNumber,
+    freightAmount,
+    advancePaid,
+    balanceAmount,
+    paymentMode,
+    shipmentStatus,
+  });
+
+  await BillingRecord.findOneAndUpdate(
+    { booking: bookingId },
+    { lrNumber: finalLRNumber },
+    { new: true }
+  );
+
+  res.status(201).json(bilty);
+});
+
+router.patch('/:id', authenticate, authorize('admin'), async (req, res) => {
+  const updates = Object.entries(req.body).reduce((acc, [key, value]) => {
+    if (allowedUpdateFields.has(key)) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+
+  if (Object.keys(updates).length === 0) {
+    return res.status(400).json({ message: 'No valid fields to update.' });
+  }
+
+  if (updates.lrNumber) {
+    updates.lrNumber = await ensureUniqueLRNumber(updates.lrNumber.trim());
+  }
+
+  const bilty = await Bilty.findByIdAndUpdate(req.params.id, updates, { new: true });
+  if (!bilty) {
+    return res.status(404).json({ message: 'Bilty not found.' });
+  }
+
+  if (updates.lrNumber) {
+    await BillingRecord.findOneAndUpdate(
+      { booking: bilty.booking },
+      { lrNumber: updates.lrNumber },
+      { new: true }
+    );
+  }
+
+  res.json(bilty);
+});
+
+router.delete('/:id', authenticate, authorize('admin'), async (req, res) => {
+  const bilty = await Bilty.findByIdAndDelete(req.params.id);
+  if (!bilty) {
+    return res.status(404).json({ message: 'Bilty not found.' });
+  }
+
+  await BillingRecord.findOneAndUpdate(
+    { booking: bilty.booking },
+    { $unset: { lrNumber: '' } },
+    { new: true }
+  );
+
+  res.json({ message: 'Bilty deleted.' });
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -100,6 +100,7 @@ app.use('/api/auth', require('./routes/auth'));
 app.use('/api/load', require('./routes/load'));
 app.use('/api/truck', require('./routes/truck'));
 app.use('/api/booking', require('./routes/booking'));
+app.use('/api/bilty', require('./routes/bilty'));
 app.use('/api/match', require('./routes/match'));
 app.use('/api/users', require('./routes/users'));
 

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -8,10 +8,50 @@ export default function AdminDashboard() {
   const [loads, setLoads] = useState([]);
   const [bookings, setBookings] = useState([]);
   const [users, setUsers] = useState([]);
+  const [bilties, setBilties] = useState([]);
   const [matchingTrucks, setMatchingTrucks] = useState({});
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
+  const [editingBiltyId, setEditingBiltyId] = useState(null);
+  const [biltyForm, setBiltyForm] = useState({
+    booking: "",
+    lrNumber: "",
+    consignorName: "",
+    consigneeName: "",
+    pickupLocation: "",
+    dropLocation: "",
+    materialType: "",
+    weight: "",
+    truckType: "",
+    driverName: "",
+    driverPhone: "",
+    vehicleNumber: "",
+    freightAmount: "",
+    advancePaid: "",
+    balanceAmount: "",
+    paymentMode: "cash",
+    shipmentStatus: "assigned"
+  });
+  const [newBilty, setNewBilty] = useState({
+    booking: "",
+    lrNumber: "",
+    consignorName: "",
+    consigneeName: "",
+    pickupLocation: "",
+    dropLocation: "",
+    materialType: "",
+    weight: "",
+    truckType: "",
+    driverName: "",
+    driverPhone: "",
+    vehicleNumber: "",
+    freightAmount: "",
+    advancePaid: "",
+    balanceAmount: "",
+    paymentMode: "cash",
+    shipmentStatus: "assigned"
+  });
 
   useEffect(() => {
     fetchData();
@@ -20,14 +60,16 @@ export default function AdminDashboard() {
   const fetchData = async () => {
     setLoading(true);
     try {
-      const [loadsRes, bookingsRes, usersRes] = await Promise.all([
+      const [loadsRes, bookingsRes, usersRes, biltiesRes] = await Promise.all([
         api.get("/load/available"),
         api.get("/booking/all"),
-        api.get("/users")
+        api.get("/users"),
+        api.get("/bilty")
       ]);
       setLoads(loadsRes.data);
       setBookings(bookingsRes.data);
       setUsers(usersRes.data);
+      setBilties(biltiesRes.data);
     } catch (error) {
       console.error("Fetch error:", error);
     } finally {
@@ -70,6 +112,95 @@ export default function AdminDashboard() {
       console.error("Error recording payment:", error);
       alert("Error recording payment");
     }
+  };
+
+  const createBilty = async (event) => {
+    event.preventDefault();
+    try {
+      await api.post("/bilty", newBilty);
+      alert("Bilty Created Successfully!");
+      setNewBilty({
+        booking: "",
+        lrNumber: "",
+        consignorName: "",
+        consigneeName: "",
+        pickupLocation: "",
+        dropLocation: "",
+        materialType: "",
+        weight: "",
+        truckType: "",
+        driverName: "",
+        driverPhone: "",
+        vehicleNumber: "",
+        freightAmount: "",
+        advancePaid: "",
+        balanceAmount: "",
+        paymentMode: "cash",
+        shipmentStatus: "assigned"
+      });
+      fetchData();
+    } catch (error) {
+      console.error("Error creating bilty:", error);
+      alert("Error creating bilty");
+    }
+  };
+
+  const startEditBilty = (bilty) => {
+    setEditingBiltyId(bilty._id);
+    setBiltyForm({
+      booking: bilty.booking?._id || "",
+      lrNumber: bilty.lrNumber || "",
+      consignorName: bilty.consignorName || "",
+      consigneeName: bilty.consigneeName || "",
+      pickupLocation: bilty.pickupLocation || "",
+      dropLocation: bilty.dropLocation || "",
+      materialType: bilty.materialType || "",
+      weight: bilty.weight || "",
+      truckType: bilty.truckType || "",
+      driverName: bilty.driverName || "",
+      driverPhone: bilty.driverPhone || "",
+      vehicleNumber: bilty.vehicleNumber || "",
+      freightAmount: bilty.freightAmount || "",
+      advancePaid: bilty.advancePaid || "",
+      balanceAmount: bilty.balanceAmount || "",
+      paymentMode: bilty.paymentMode || "cash",
+      shipmentStatus: bilty.shipmentStatus || "assigned"
+    });
+  };
+
+  const updateBilty = async (event) => {
+    event.preventDefault();
+    try {
+      const { booking, ...payload } = biltyForm;
+      await api.patch(`/bilty/${editingBiltyId}`, payload);
+      alert("Bilty Updated Successfully!");
+      setEditingBiltyId(null);
+      fetchData();
+    } catch (error) {
+      console.error("Error updating bilty:", error);
+      alert("Error updating bilty");
+    }
+  };
+
+  const deleteBilty = async (biltyId) => {
+    if (!window.confirm("Delete this bilty record?")) return;
+    try {
+      await api.delete(`/bilty/${biltyId}`);
+      alert("Bilty Deleted Successfully!");
+      fetchData();
+    } catch (error) {
+      console.error("Error deleting bilty:", error);
+      alert("Error deleting bilty");
+    }
+  };
+
+  const cancelEditBilty = () => {
+    setEditingBiltyId(null);
+  };
+
+  const handleBiltyChange = (setter) => (event) => {
+    const { name, value } = event.target;
+    setter((prev) => ({ ...prev, [name]: value }));
   };
 
   const API_BASE = getApiBaseUrl();
@@ -230,6 +361,338 @@ export default function AdminDashboard() {
                   </button>
                 )}
               </div>
+            </div>
+          ))}
+        </section>
+
+        <section className="stack">
+          <h3 className="section-title">Bilty Management</h3>
+          <div className="card">
+            <form className="stack" onSubmit={createBilty}>
+              <div className="toolbar">
+                <input
+                  className="input"
+                  name="booking"
+                  placeholder="Booking ID"
+                  value={newBilty.booking}
+                  onChange={handleBiltyChange(setNewBilty)}
+                />
+                <input
+                  className="input"
+                  name="lrNumber"
+                  placeholder="LR Number (optional)"
+                  value={newBilty.lrNumber}
+                  onChange={handleBiltyChange(setNewBilty)}
+                />
+              </div>
+              <div className="toolbar">
+                <input
+                  className="input"
+                  name="consignorName"
+                  placeholder="Consignor Name"
+                  value={newBilty.consignorName}
+                  onChange={handleBiltyChange(setNewBilty)}
+                />
+                <input
+                  className="input"
+                  name="consigneeName"
+                  placeholder="Consignee Name"
+                  value={newBilty.consigneeName}
+                  onChange={handleBiltyChange(setNewBilty)}
+                />
+              </div>
+              <div className="toolbar">
+                <input
+                  className="input"
+                  name="pickupLocation"
+                  placeholder="Pickup Location"
+                  value={newBilty.pickupLocation}
+                  onChange={handleBiltyChange(setNewBilty)}
+                />
+                <input
+                  className="input"
+                  name="dropLocation"
+                  placeholder="Drop Location"
+                  value={newBilty.dropLocation}
+                  onChange={handleBiltyChange(setNewBilty)}
+                />
+              </div>
+              <div className="toolbar">
+                <input
+                  className="input"
+                  name="materialType"
+                  placeholder="Material Type"
+                  value={newBilty.materialType}
+                  onChange={handleBiltyChange(setNewBilty)}
+                />
+                <input
+                  className="input"
+                  name="weight"
+                  type="number"
+                  placeholder="Weight (T)"
+                  value={newBilty.weight}
+                  onChange={handleBiltyChange(setNewBilty)}
+                />
+              </div>
+              <div className="toolbar">
+                <input
+                  className="input"
+                  name="truckType"
+                  placeholder="Truck Type"
+                  value={newBilty.truckType}
+                  onChange={handleBiltyChange(setNewBilty)}
+                />
+                <input
+                  className="input"
+                  name="vehicleNumber"
+                  placeholder="Vehicle Number"
+                  value={newBilty.vehicleNumber}
+                  onChange={handleBiltyChange(setNewBilty)}
+                />
+              </div>
+              <div className="toolbar">
+                <input
+                  className="input"
+                  name="driverName"
+                  placeholder="Driver Name"
+                  value={newBilty.driverName}
+                  onChange={handleBiltyChange(setNewBilty)}
+                />
+                <input
+                  className="input"
+                  name="driverPhone"
+                  placeholder="Driver Phone"
+                  value={newBilty.driverPhone}
+                  onChange={handleBiltyChange(setNewBilty)}
+                />
+              </div>
+              <div className="toolbar">
+                <input
+                  className="input"
+                  name="freightAmount"
+                  type="number"
+                  placeholder="Freight Amount"
+                  value={newBilty.freightAmount}
+                  onChange={handleBiltyChange(setNewBilty)}
+                />
+                <input
+                  className="input"
+                  name="advancePaid"
+                  type="number"
+                  placeholder="Advance Paid"
+                  value={newBilty.advancePaid}
+                  onChange={handleBiltyChange(setNewBilty)}
+                />
+                <input
+                  className="input"
+                  name="balanceAmount"
+                  type="number"
+                  placeholder="Balance Amount"
+                  value={newBilty.balanceAmount}
+                  onChange={handleBiltyChange(setNewBilty)}
+                />
+              </div>
+              <div className="toolbar">
+                <select
+                  className="select"
+                  name="paymentMode"
+                  value={newBilty.paymentMode}
+                  onChange={handleBiltyChange(setNewBilty)}
+                >
+                  <option value="cash">Cash</option>
+                  <option value="bank">Bank</option>
+                  <option value="upi">UPI</option>
+                  <option value="card">Card</option>
+                </select>
+                <select
+                  className="select"
+                  name="shipmentStatus"
+                  value={newBilty.shipmentStatus}
+                  onChange={handleBiltyChange(setNewBilty)}
+                >
+                  <option value="assigned">Assigned</option>
+                  <option value="in-transit">In Transit</option>
+                  <option value="delivered">Delivered</option>
+                </select>
+                <button className="btn btn-primary" type="submit">
+                  Create Bilty
+                </button>
+              </div>
+            </form>
+          </div>
+
+          {bilties.map((bilty) => (
+            <div key={bilty._id} className="card">
+              <div className="page-header">
+                <div>
+                  <p style={{ margin: 0, fontWeight: 600 }}>
+                    Bilty {bilty.lrNumber}
+                  </p>
+                  <p className="text-muted" style={{ margin: "6px 0 0" }}>
+                    Booking #{bilty.booking?._id?.slice(-6)} • Status: {bilty.shipmentStatus}
+                  </p>
+                </div>
+                <div className="toolbar">
+                  <button
+                    className="btn btn-secondary"
+                    onClick={() => startEditBilty(bilty)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    className="btn btn-outline"
+                    onClick={() => deleteBilty(bilty._id)}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+
+              {editingBiltyId === bilty._id && (
+                <form className="stack" onSubmit={updateBilty} style={{ marginTop: 16 }}>
+                  <div className="toolbar">
+                    <input
+                      className="input"
+                      name="lrNumber"
+                      placeholder="LR Number"
+                      value={biltyForm.lrNumber}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    />
+                    <input
+                      className="input"
+                      name="consignorName"
+                      placeholder="Consignor Name"
+                      value={biltyForm.consignorName}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    />
+                    <input
+                      className="input"
+                      name="consigneeName"
+                      placeholder="Consignee Name"
+                      value={biltyForm.consigneeName}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    />
+                  </div>
+                  <div className="toolbar">
+                    <input
+                      className="input"
+                      name="pickupLocation"
+                      placeholder="Pickup Location"
+                      value={biltyForm.pickupLocation}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    />
+                    <input
+                      className="input"
+                      name="dropLocation"
+                      placeholder="Drop Location"
+                      value={biltyForm.dropLocation}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    />
+                    <input
+                      className="input"
+                      name="materialType"
+                      placeholder="Material Type"
+                      value={biltyForm.materialType}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    />
+                  </div>
+                  <div className="toolbar">
+                    <input
+                      className="input"
+                      name="weight"
+                      type="number"
+                      placeholder="Weight (T)"
+                      value={biltyForm.weight}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    />
+                    <input
+                      className="input"
+                      name="truckType"
+                      placeholder="Truck Type"
+                      value={biltyForm.truckType}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    />
+                    <input
+                      className="input"
+                      name="vehicleNumber"
+                      placeholder="Vehicle Number"
+                      value={biltyForm.vehicleNumber}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    />
+                  </div>
+                  <div className="toolbar">
+                    <input
+                      className="input"
+                      name="driverName"
+                      placeholder="Driver Name"
+                      value={biltyForm.driverName}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    />
+                    <input
+                      className="input"
+                      name="driverPhone"
+                      placeholder="Driver Phone"
+                      value={biltyForm.driverPhone}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    />
+                  </div>
+                  <div className="toolbar">
+                    <input
+                      className="input"
+                      name="freightAmount"
+                      type="number"
+                      placeholder="Freight Amount"
+                      value={biltyForm.freightAmount}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    />
+                    <input
+                      className="input"
+                      name="advancePaid"
+                      type="number"
+                      placeholder="Advance Paid"
+                      value={biltyForm.advancePaid}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    />
+                    <input
+                      className="input"
+                      name="balanceAmount"
+                      type="number"
+                      placeholder="Balance Amount"
+                      value={biltyForm.balanceAmount}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    />
+                  </div>
+                  <div className="toolbar">
+                    <select
+                      className="select"
+                      name="paymentMode"
+                      value={biltyForm.paymentMode}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    >
+                      <option value="cash">Cash</option>
+                      <option value="bank">Bank</option>
+                      <option value="upi">UPI</option>
+                      <option value="card">Card</option>
+                    </select>
+                    <select
+                      className="select"
+                      name="shipmentStatus"
+                      value={biltyForm.shipmentStatus}
+                      onChange={handleBiltyChange(setBiltyForm)}
+                    >
+                      <option value="assigned">Assigned</option>
+                      <option value="in-transit">In Transit</option>
+                      <option value="delivered">Delivered</option>
+                    </select>
+                    <button className="btn btn-primary" type="submit">
+                      Save Changes
+                    </button>
+                    <button className="btn btn-outline" type="button" onClick={cancelEditBilty}>
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              )}
             </div>
           ))}
         </section>

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -94,6 +94,7 @@ export default function LandingPage() {
             </p>
           </div>
         </section>
+
       </div>
     </div>
   );

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -54,6 +54,16 @@ export default function Register() {
     return response.data.user.role;
   };
 
+  const isFirebaseAvailable = async () => {
+    if (!hasFirebaseConfig) return false;
+    try {
+      const response = await api.get("/auth/firebase/status");
+      return Boolean(response.data?.available);
+    } catch (err) {
+      return false;
+    }
+  };
+
   const validateRegisterForm = (data) => {
     const { companyName, name, email, phone, password } = data;
 
@@ -93,10 +103,12 @@ export default function Register() {
     setLoading(true);
 
     try {
-      const role = hasFirebaseConfig
-        ? await registerWithFirebase()
-        : await registerWithApi();
-      if (role === "admin") navigate("/admin", { replace: true });
+      const role =
+        hasFirebaseConfig && (await isFirebaseAvailable())
+          ? await registerWithFirebase()
+          : await registerWithApi();
+      if (role === "superadmin") navigate("/superadmin", { replace: true });
+      else if (role === "admin") navigate("/admin", { replace: true });
       else if (role === "driver") navigate("/driver", { replace: true });
       else navigate("/dashboard", { replace: true });
     } catch (err) {
@@ -191,6 +203,7 @@ export default function Register() {
             <option value="customer">Customer</option>
             <option value="driver">Driver</option>
             <option value="admin">Admin</option>
+            <option value="superadmin">Super Admin</option>
           </select>
 
           <button type="submit" disabled={loading} className="btn btn-primary">


### PR DESCRIPTION
### Motivation
- Prevent 503s and broken login/register UX when Firebase is not initialized by making the frontend detect backend Firebase availability and fall back to API auth flows. 
- Allow an emergency/owner-level `superadmin` role to bypass role checks for admin flows. 
- Improve auditability by recording login attempts and provide LR/billing support for the LR lifecycle and admin management. 

### Description
- Backend: added `LoginLog` and `BillingRecord` mongoose models, extended `User` role enum to include `superadmin`, and updated `authorize` middleware to let `superadmin` bypass role checks. 
- Backend auth changes: added `firebaseReady()` checks and a new endpoint `GET /api/auth/firebase/status`, and wired `logLoginAttempt` calls into `register`, `login`, and Firebase login flows to persist success/failure attempts. 
- Bilty & booking: added `backend/routes/bilty.js` with LR generation, uniqueness guarantees, create/patch/delete endpoints, updated `booking` flow to create/update `BillingRecord` and sync payment/`lrNumber`, and registered the bilty route in `server.js`. 
- Frontend: added `isFirebaseAvailable()` that queries `GET /api/auth/firebase/status` and gates Firebase email/password and Google sign-ins in `Login.jsx` and Firebase registration in `Register.jsx`, falling back to API auth when unavailable; updated routing to handle `superadmin`. 
- Admin UI: added bilty management UI in `frontend/src/pages/AdminDashboard.jsx` for creating, editing, and deleting bilties and integrated fetching of `/bilty`. 

### Testing
- Ran `npm test` in the `backend` which prints `No tests defined` and completed successfully. 
- Ran `npm test` in the `frontend` which prints `No tests defined` and completed successfully. 
- Manual validation performed by wiring frontend to backend endpoints to ensure Firebase availability is checked before attempting Firebase flows and that API fallbacks work (no automated tests were added).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988dd298e408331bccf1f0c80fd38a3)