### PR TITLE
🛠️ Fix ESLint no-unused-vars failure in AdminDashboard

### DIFF
--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -171,7 +171,8 @@ export default function AdminDashboard() {
   const updateBilty = async (event) => {
     event.preventDefault();
     try {
-      const { booking, ...payload } = biltyForm;
+      const { booking: _booking, ...payload } = biltyForm;
+
       await api.patch(`/bilty/${editingBiltyId}`, payload);
       alert("Bilty Updated Successfully!");
       setEditingBiltyId(null);


### PR DESCRIPTION

### **The CI pipeline was failing during the lint-test step with the following ESLint error:**
'booking' is assigned a value but never used.
Allowed unused vars must match /^[A-Z_]/u


**File affected:**
frontend/src/pages/AdminDashboard.jsx#L174


This caused the GitHub Actions workflow to exit with code 1.

✅ Fix
Renamed the unused destructured variable booking to _booking while preparing the payload for bilty update:

<img width="1378" height="697" alt="image" src="https://github.com/user-attachments/assets/bcf3d84e-f445-4741-881e-8414e2fa49cb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor code quality improvement to resolve lint warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->