### PR TITLE
Add Axios response interceptor for global 401 handling and retries

### DIFF
--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -22,12 +22,22 @@ api.interceptors.response.use(
   (response) => response,
   async (error) => {
     const config = error.config;
+    const status = error.response?.status;
+
+    if (status === 401) {
+      safeStorage.remove("accessToken");
+      if (typeof window !== "undefined") {
+        window.location.assign("/login");
+      }
+      return Promise.reject(error);
+    }
+
     if (!config) {
       return Promise.reject(error);
     }
 
     const shouldRetry =
-      (!error.response || error.response.status >= 500) &&
+      (!error.response || status >= 500) &&
       (config.method === "get" || config.method === "head");
 
     if (shouldRetry && config.metadata.retryCount < 2) {


### PR DESCRIPTION
Adds a global Axios response interceptor to handle 401 responses consistently (clear token + redirect).
Keeps centralized retry behavior for transient failures.
Reduces duplicated error handling across components.
axios.js :  added response interceptor for 401 and retry logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication session management: The app now properly handles expired or invalid authentication by automatically clearing your session and redirecting you to the login page when access is denied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->